### PR TITLE
Adds POEM 044 for OpenMDAO-specific warning classes

### DIFF
--- a/POEM_044.md
+++ b/POEM_044.md
@@ -1,0 +1,95 @@
+POEM ID: 044  
+Title: Global User Preferences  
+authors: [robfalck]  
+Competing POEMs: N/A  
+Related POEMs: N/A  
+Associated implementation PR:
+
+Status:
+
+- [x] Active
+- [ ] Requesting decision
+- [ ] Accepted
+- [ ] Rejected
+- [ ] Integrated
+
+
+Motivation
+----------
+OpenMDAO currently has case-by-case settings for the verbosity of various warnings and other information.
+Experienced users may wish to silence a lot of these warnings in most cases.
+For this sort of behavior, it makes sense that a user may want to save their global preferences for use across cases.
+This POEM proposes the addition of a user preferences file: ~/.openmdao.cfg
+
+
+Config File Guidelines
+----------------------
+
+The following are some guidelines for the configuration file.
+
+1. The default configuration options will be stored in the OpenMDAO repo and installed when OpenMDAO is installed.
+
+We'll nominally call this file `/path_to_openmdao/openmdao.cfg`
+
+2. A user-specific set of options will be stored in `~/.openmdao.cfg`
+
+Values set in `~/.openmdao.cfg` will override values in `/path_to_openmdao/openmdao.cfg`
+
+3. The .openmdao.cfg file will initially be used to store options pertaining to the verbosity of warnings.
+
+The settings in the config should not affect results, although this may eventually change.
+
+4. The OpenMDAO command line should have a `config` option to create the file or view its current values.
+
+`openmdao config --create` will create a new default configuration file at ~/.openmdao.cfg
+
+`openmdao config` will show the contents of the configuration file.
+
+`openmdao config --diff` will show the difference between the user's settings and the defaults in the OpenMDAO directory.
+
+5. To avoid the addition of dependencies, use the configparser module in the standard library for the file format.
+
+6. Values stored in the config file will be _defaults_ that can be overridden in global openmdao options.
+
+6. Proposed structure
+
+```
+[checks]
+auto_ivc_warnings = yes
+comp_has_no_outputs = yes
+cycles = no
+dup_inputs = yes
+missing_recorders = yes
+out_of_order = yes
+promotions = no
+solvers = yes
+system = yes
+unconnected_inputs = no
+
+[component_warnings]
+distributed_component_no_src_indices = warn
+
+[connection_warnings]
+unitless_to_units = warn
+
+[optimizer_warnings]
+singular_jac_behavior = warn
+
+```
+
+Checks will be set to enabled (1) be disabled (0)
+Warnings will use the numpy seterr apporach for parsing warnings:
+
+Warnings will simply warn when set to `warn`.
+Disabling a warnings will be performed by setting it to `ignore`.
+Warnings can be promoted to errors by setting them to `raise`.
+
+Setting options in a script
+---------------------------
+
+A new nested dictionary will be added:  `openmdao.api.options`.
+
+```
+om.options['connection_warnings']['unitless_to_units'] = 'ignore'
+om.options['optimizer_warnings']['singular_jac_behavior'] = 'raise'
+```

--- a/POEM_044.md
+++ b/POEM_044.md
@@ -108,7 +108,7 @@ To conform to a numpy-like interface, an action of `'raise'` will have the same 
 
 The following table is from the Python warning documentation:
 
-| Value       | Disposition |                                                                                                           |
+| Value       | Disposition                                                                                                             |
 | ----------- | ----------------------------------------------------------------------------------------------------------------------- |
 | "default"   | print the first occurrence of matching warnings for each location (module + line number) where the warning is issued    |
 | "error"     | turn matching warnings into exceptions  (OpenMDAO will also accept "raise")                                             |

--- a/POEM_044.md
+++ b/POEM_044.md
@@ -1,4 +1,4 @@
-POEM ID: 045  
+POEM ID: 044  
 Title: OpenMDAO-Specific Warnings  
 authors: [robfalck]  
 Competing POEMs: N/A  

--- a/POEM_044.md
+++ b/POEM_044.md
@@ -55,24 +55,24 @@ The settings in the config should not affect results, although this may eventual
 
 ```
 [checks]
-auto_ivc_warnings = yes
-comp_has_no_outputs = yes
-cycles = no
-dup_inputs = yes
-missing_recorders = yes
-out_of_order = yes
-promotions = no
-solvers = yes
-system = yes
-unconnected_inputs = no
+auto_ivc_warnings = 1
+comp_has_no_outputs = 1
+cycles = 0
+dup_inputs = 1
+missing_recorders = 1
+out_of_order = 1
+promotions = 0
+solvers = 1
+system = 1
+unconnected_inputs = 0
 
-[component_warnings]
+[Component.warnings]
 distributed_component_no_src_indices = warn
 
-[connection_warnings]
+[Connection.warnings]
 unitless_to_units = warn
 
-[optimizer_warnings]
+[Driver.warnings]
 singular_jac_behavior = warn
 
 ```
@@ -90,6 +90,6 @@ Setting options in a script
 A new nested dictionary will be added:  `openmdao.api.options`.
 
 ```
-om.options['connection_warnings']['unitless_to_units'] = 'ignore'
-om.options['optimizer_warnings']['singular_jac_behavior'] = 'raise'
+om.options['Connection.warnings']['unitless_to_units'] = 'ignore'
+om.options['Driver.warnings']['singular_jac_behavior'] = 'raise'
 ```

--- a/POEM_044.md
+++ b/POEM_044.md
@@ -1,5 +1,5 @@
-POEM ID: 044  
-Title: Global User Preferences  
+POEM ID: 045  
+Title: OpenMDAO-Specific Warnings  
 authors: [robfalck]  
 Competing POEMs: N/A  
 Related POEMs: N/A  
@@ -16,80 +16,124 @@ Status:
 
 Motivation
 ----------
-OpenMDAO currently has case-by-case settings for the verbosity of various warnings and other information.
-Experienced users may wish to silence a lot of these warnings in most cases.
-For this sort of behavior, it makes sense that a user may want to save their global preferences for use across cases.
-This POEM proposes the addition of a user preferences file: ~/.openmdao.cfg
+
+OpenMDAO currently uses Python's UserWarning as the basis for most warnings.
+Some warnings can be annoyingly verbose, but filtering out all UserWarnings is likely overkill.
+This POEM proposes providing OpenMDAO-specific warnings and some API functions to allow the user to silence unwanted warnings.
 
 
-Config File Guidelines
-----------------------
+Proposed Warning Classes
+------------------------
 
-The following are some guidelines for the configuration file.
+There are two goals with creating OpenMDAO-specific warning classes.
 
-1. The default configuration options will be stored in the OpenMDAO repo and installed when OpenMDAO is installed.
+1. Make it possible to silence or otherwise alter the behavior of some warnings.
+2. Don't make an unwieldy number of warning classes.
 
-We'll nominally call this file `/path_to_openmdao/openmdao.cfg`
+Using a hierarchical approach, this proposes the following:
 
-2. A user-specific set of options will be stored in `~/.openmdao.cfg`
+The top of the OpenMDAO warning hierarchy will be class `OpenMDAOWarning`, derived from the UserWarning class.
+The following classes will derive from `OpenMDAOWarning`.
 
-Values set in `~/.openmdao.cfg` will override values in `/path_to_openmdao/openmdao.cfg`
+| Warning Class           | String Name         | Default Behavior     | Description                                                         |
+| ----------------------- | ------------------- | -------------------- | ------------------------------------------------------------------- |
+| SetupWarning            | warn_setup          | always               | Parent-class of all setup-time warnings (not errors).               |
+| SolverWarning           | warn_solver         | always               | Warning encountered during solver execution.                        |
+| DriverWarning           | warn_driver         | always               | Warning encountered during driver execution.                        |
+| UnusedOptionWarning     | warn_unused_option  | always               | A given option or argument has no effect.                           |
+| CaseRecorderWarning     | warn_case_recorder  | always               | Warning encountered by a case recorder or case reader.              |
+| CacheWarning            | warn_cache          | always               | A cache is invalid and must be discarded.                           |
 
-3. The .openmdao.cfg file will initially be used to store options pertaining to the verbosity of warnings.
+For fine-grain control of setup warnings, the following classes will derive from `SetupWarning`.
 
-The settings in the config should not affect results, although this may eventually change.
+| Warning Class               | String Name         | Default Behavior     | Description                                                            |
+| --------------------------- | ------------------- | -------------------- | ---------------------------------------------------------------------- |
+| PromotionWarning            | warn_promotion      | always               | Behavior regarding ambiguities due to promotion or set_input_defaults. |
+| UnitsWarning                | warn_units          | always               | Warning pertaining to units (usually unitless to dimensional).         |
+| DerivativesWarning          | warn_derivatives    | always               | Warning regarding derivatives (usually approximation or coloring).     |
+| MPIWarning                  | warn_mpi            | always               | Warning regarding MPI availability.                                    |
+| DistributedComponentWarning | warn_distributed    | always               | Warning regarding distributed component setup.                         |
 
-4. The OpenMDAO command line should have a `config` option to create the file or view its current values.
 
-`openmdao config --create` will create a new default configuration file at ~/.openmdao.cfg
+Another non-user-facing warning will also be created, derived from UserWarning:  `AllowableSetupError`.  This class
+will default to a behavior of "error" and will allow some setup errors to pass in order for the N2 to be built.  This  way,
+even if `OpenMDAOWarning` is set to `'ignore'`, setup errors will continue to be triggered unless setup is being performed
+only for the purpose of creating an N2 diagram via the command line interface.
 
-`openmdao config` will show the contents of the configuration file.
 
-`openmdao config --diff` will show the difference between the user's settings and the defaults in the OpenMDAO directory.
+Setting Warning Verbosity
+-------------------------
 
-5. To avoid the addition of dependencies, use the configparser module in the standard library for the file format.
+OpenMDAO-specific warnings may take effect prior to setup.
+For example, some warnings are triggered when adding inputs.
+For this reason, the warning behavior needs to be triggered by a function call before the first warning is issued
 
-6. Values stored in the config file will be _defaults_ that can be overridden in global openmdao options.
+The verbosity of all OpenMDAO warnings will be set when OpenMDAO is initially imported.
 
-6. Proposed structure
-
-```
-[checks]
-auto_ivc_warnings = 1
-comp_has_no_outputs = 1
-cycles = 0
-dup_inputs = 1
-missing_recorders = 1
-out_of_order = 1
-promotions = 0
-solvers = 1
-system = 1
-unconnected_inputs = 0
-
-[Component.warnings]
-distributed_component_no_src_indices = warn
-
-[Connection.warnings]
-unitless_to_units = warn
-
-[Driver.warnings]
-singular_jac_behavior = warn
+Users will be free to use Python's warnings filter system:
 
 ```
+import warnings
+import openmdao.api as om
+warnings.filterwarnings(action='ignore', category=om.UnitsWarning)
+```
 
-Checks will be set to enabled (1) be disabled (0)
-Warnings will use the numpy seterr approach for parsing warnings:
+In addition, an OpenMDAO API function will also be available.
+This function will be similar to numpy's seterr method.
 
-Warnings will simply warn when set to `warn`.
-Disabling a warnings will be performed by setting it to `ignore`.
-Warnings can be promoted to errors by setting them to `raise`.
+```
+import openmdao.api as om
+om.filter_warnings(warn_units='ignore')
+```
 
-Setting options in a script
+Issuing Warnings
+----------------
+
+To issue warnings in a standard format, the OpenMDAO API will have a
+new `issue_warning` method that functions similarly to the existing simple_warning function.
+This will take the same "stringified" name that the filter_warnings function takes, along
+with a prefix to be used that will typically identify the path of the system issuing the warning.
+
+```
+import openmdao.api as om
+
+om.issue_warning(warn_mpi='Unable to perform action, MPI is not available.', prefix=self.pathname)
+```
+
+Valid Actions for Filtering
 ---------------------------
 
-A new nested dictionary will be added:  `openmdao.api.options`.
+OpenMDAO will use the same actions that are available in Python, with one addition.
+To conform to a numpy-like interface, an action of `'raise'` will have the same effect as `'error'`.
+
+The following table is from the Python warning documentation:
+
+| Value       | Disposition |                                                                                                           |
+| ----------- | ----------------------------------------------------------------------------------------------------------------------- |
+| "default"   | print the first occurrence of matching warnings for each location (module + line number) where the warning is issued    |
+| "error"     | turn matching warnings into exceptions  (OpenMDAO will also accept "raise")                                             |
+| "ignore"    | never print matching warnings                                                                                           |
+| "always"    | always print matching warnings                                                                                          |
+| "module"    | print the first occurrence of matching warnings for each module where the warning is issued (regardless of line number) |
+| "once"      | print only the first occurrence of matching warnings, regardless of location                                            |
+
+
+Registering Warnings
+--------------------
+
+Developers of libraries built on top of OpenMDAO may want to add their own warnings to the ecosystem.
+To do this, they should define their warning class and provide it with two class properties: a name and a default filter.
 
 ```
-om.options['Connection.warnings']['unitless_to_units'] = 'ignore'
-om.options['Driver.warnings']['singular_jac_behavior'] = 'raise'
+class MySetupWarningClass(om.SetupWarning):
+    name = 'warn_my_setup'
+    filter = 'always'
 ```
+
+Then, to register it with OpenMDAO:
+
+```
+om.register_warning(MySetupWarning)
+```
+
+The `register_warning` function will apply the filter and add the warning class to an internal dictionary so that it can be accessed using its string name.

--- a/POEM_044.md
+++ b/POEM_044.md
@@ -7,9 +7,9 @@ Associated implementation PR:
 
 Status:
 
-- [x] Active
+- [ ] Active
 - [ ] Requesting decision
-- [ ] Accepted
+- [x] Accepted
 - [ ] Rejected
 - [ ] Integrated
 


### PR DESCRIPTION
This is a proposal for OpenMDAO-specific warning classes that allow finder control over what warnings the user sees during use.  Originally we included a persistent user-preferences configuration, but that's being delayed for now.