### PR TITLE
Added cross-reference link for implementation PR to the POEM template.

### DIFF
--- a/POEM_template.md
+++ b/POEM_template.md
@@ -3,7 +3,7 @@ Title:
 authors: github_user_name (optional real name)  
 Competing POEMs: [list any other POEMs which are incompatible with this one]  
 Related POEMs: [list any other POEMs which are related (but still compatible) with this one]  
-Associated implementation PR:
+Associated implementation PR: OpenMDAO/OpenMDAO#pr_number or N/A  
 
 Status:
 


### PR DESCRIPTION
Adds a link of the form `OpenMDAO/OpenMDAO#pr_number` to the POEM template to make it easier to cross reference to proposed implementation on the main OpenMDAO repo.