### PR TITLE
Added POEM 061: Require design variable outputs be tagged with `openmdao:allow_desvar`

### DIFF
--- a/POEM_061.md
+++ b/POEM_061.md
@@ -53,3 +53,5 @@ By default, this tag will be applied to outputs of
 - ImplicitComponent
 
 Checking whether a variable can be validly made a design variable is then just a matter of testing if it has this tag applied to it.
+
+In the rare corner case that a user implements their own IndepVarComp-like component, they will be able to tag outputs to allow them to be design variables.

--- a/POEM_061.md
+++ b/POEM_061.md
@@ -3,7 +3,7 @@ Title: The `allow_desvar` tag
 authors: @robfalck  
 Competing POEMs:  
 Related POEMs:  
-Associated implementation PR:
+Associated implementation PR: [#2350](https://github.com/OpenMDAO/OpenMDAO/pull/2350)
 
 Status:
 

--- a/POEM_061.md
+++ b/POEM_061.md
@@ -1,5 +1,5 @@
 POEM ID: 061  
-Title: The `allow_desvar` tag  
+Title: The `openmdao:allow_desvar` tag  
 authors: @robfalck  
 Competing POEMs:  
 Related POEMs:  
@@ -7,9 +7,9 @@ Associated implementation PR: [#2350](https://github.com/OpenMDAO/OpenMDAO/pull/
 
 Status:
 
-- [x] Active
+- [ ] Active
 - [ ] Requesting decision
-- [ ] Accepted
+- [x] Accepted
 - [ ] Rejected
 - [ ] Integrated
 

--- a/POEM_061.md
+++ b/POEM_061.md
@@ -1,0 +1,55 @@
+POEM ID: 061  
+Title: The `allow_desvar` tag  
+authors: @robfalck  
+Competing POEMs:  
+Related POEMs:  
+Associated implementation PR:
+
+Status:
+
+- [x] Active
+- [ ] Requesting decision
+- [ ] Accepted
+- [ ] Rejected
+- [ ] Integrated
+
+
+## Motivation
+
+Currently a user can assign any output as a design variable, though this is almost certainly unwanted behavior.
+Still, the possibility exists that a user may wish to create an IndepVarComp-like component of their own, so we cannot simply disallow design variables on all non IVC outputs.
+
+```
+import openmdao.api as om
+
+prob = om.Problem()
+root = prob.model
+
+prob.driver = om.ScipyOptimizeDriver()
+
+root.add_subsystem('initial_comp', om.ExecComp(['x = 10']), promotes_outputs=['x'])
+
+outer_group = root.add_subsystem('outer_group', om.Group(), promotes_inputs=['x'])
+inner_group = outer_group.add_subsystem('inner_group', om.Group(), promotes_inputs=['x'])
+
+c1 = inner_group.add_subsystem('c1', om.ExecComp(['y = x * 2.0',  'z = x ** 2']),  promotes_inputs=['x'])
+
+c1.add_design_var('x', lower=0, upper=5)
+c1.add_constraint('y', lower=1.5)
+c1.add_objective('z')
+
+prob.setup()
+
+prob.run_driver()
+prob.list_problem_vars()
+```
+
+## Solution
+
+To get around this, we will create a new tag: `openmdao:allow_desvar`, and any attempt to assign a design variable to an output _without_ this tag will result in an exception be raised.
+
+By default, this tag will be applied to outputs of
+- IndepVarComp
+- ImplicitComponent
+
+Checking whether a variable can be validly made a design variable is then just a matter of testing if it has this tag applied to it.


### PR DESCRIPTION
This adds an openmdao-specific tag that will only allow design variables to be assigned to outputs with the tag `openmdao:allow_desvar`.  This will prevent users from accidentally assigning design variables to incorrect outputs or inputs unless those inputs are connected to an auto-IVC.