### PR TITLE
POEM 078: Filter list_inputs to get user-settable inputs.

### DIFF
--- a/POEM_078.md
+++ b/POEM_078.md
@@ -7,9 +7,9 @@ Associated implementation PR: TBD
 
 Status:
 
-- [x] Active
+- [ ] Active
 - [ ] Requesting decision
-- [ ] Accepted
+- [x] Accepted
 - [ ] Rejected
 - [ ] Integrated
 

--- a/POEM_078.md
+++ b/POEM_078.md
@@ -1,0 +1,54 @@
+POEM ID:  078  
+Title: Add ability to filter inputs to only those that are connected to IndepVarComp.  
+authors: rfalck (Rob Falck)  
+Competing POEMs:  
+Related POEMs:  
+Associated implementation PR: TBD  
+
+Status:
+
+- [x] Active
+- [ ] Requesting decision
+- [ ] Accepted
+- [ ] Rejected
+- [ ] Integrated
+
+## Motivation
+User's have requested a way of knowing which inputs they are ultimately responsible for setting.
+The recently implemented inputs report achieves this in a graphical format, but there is also some desire to do this programmatically.
+
+## Description
+It makes sense to implement this capability as part of `System.list_inputs`.
+This POEM proposes the following new arguments
+
+The first is `is_indep_var`:
+```
+is_indep_var : bool or None
+    If None (the default), do no additional filtering of the inputs.
+    If this is set to True, then list_inputs will only list those inputs which are connected to an output that is tagged with `openmdao:indep_var`.
+    If set to False, it will only show those inputs that are _not_ connected to outputs tagged with `openmdao:indep_var`.
+```
+
+The second new argument to `list_inputs` is `is_design_var`.
+
+```
+is_design_var : bool or None
+    If None (the default), do no additional filtering of the inputs.
+    If this is set to True, then list_inputs will only list those inputs which are connected to outputs that are design variables for the driver.
+    If set to False, it will only show those inputs that are _not_ connected to outputs that are not design variables for the driver.
+```
+
+Therefore, running
+
+```python
+p.model.list_inputs(is_indep_var=True)
+```
+
+will provide inputs that the user can ultimately change, though some of them maybe be overridden by the Driver as design variables.
+Running
+
+```python
+p.model.list_inputs(is_indep_var=True, is_design_var=False)
+```
+
+Will show those variables that should be set by the user and whose values will not be overridden by the Driver.


### PR DESCRIPTION
This POEM proposes adding the ability to filter inputs by their status as independent variables and as design variables. This is similar to the functionality of the inputs report, but in a programmatic way.